### PR TITLE
doc: replace "GeoDa OpenJS" with "GeoDa AI"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.DS_Store

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,17 +2,17 @@
 
 ## Glossary
 
-* **Advisory Committee (AC).**  A group of people with representation from a variety of GeoDa OpenJS's constituencies including Users, End-users and Collaborators who provide advice to the Technical Steering Committee.
+* **Advisory Committee (AC).**  A group of people with representation from a variety of GeoDa AI's constituencies including Users, End-users and Collaborators who provide advice to the Technical Steering Committee.
 
 * <strong id=facilitator>Facilitator.</strong>  A member of a governance body who is responsible for facilitating the consensus-based decision making process and acting as a representative to other governance bodies.
 
 * <strong id=governance-body>Governance body</strong> Any of the Advisory Committee, Technical Steering Committee, and Working Groups.
 
-* <strong id=user>Users.</strong> Developers who use GeoDa OpenJS libraries but haven't contributed to them (yet).
+* <strong id=user>Users.</strong> Developers who use GeoDa AI libraries but haven't contributed to them (yet).
 
-* <strong id=end-user>End-users</strong>. People who consume spatial data analysis tools and AI assistants built using GeoDa OpenJS libraries.
+* <strong id=end-user>End-users</strong>. People who consume spatial data analysis tools and AI assistants built using GeoDa AI libraries.
 
-* **Technical Steering Committee (TSC).**  A group of people who set GeoDa OpenJS's technical & product direction.
+* **Technical Steering Committee (TSC).**  A group of people who set GeoDa AI's technical & product direction.
 
 * <strong id=wg>Working Groups (WG)</strong>.  A group of people who have a familiarity and interest in a given area; may be cross-cutting (e.g. "Documentation") or focused on a given area (e.g. "Spatial Analysis" or "AI Integration"). These are formally recognized by the TSC, but may form informally.
 
@@ -25,7 +25,7 @@
 The Advisory Committee provides perspective and advice to the Technical Steering Committee. This advice is non-binding.
 
 #### Membership
-* Membership on the Advisory Committee shall include representatives from major GeoDa OpenJS constituencies (Collaborators, Contributors, Users and End-Users) who are committed to fulfilling [GeoDa OpenJS's vision and mission](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md#section-0-guiding-principles-optional).
+* Membership on the Advisory Committee shall include representatives from major GeoDa AI constituencies (Collaborators, Contributors, Users and End-Users) who are committed to fulfilling [GeoDa AI's vision and mission](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md#section-0-guiding-principles-optional).
 * Membership on the Advisory Committee is not time limited.
 * The target size of the Advisory Committee is 3-6 members, but there is no fixed size.
 * Once established the Advisory Committee sets its own membership through the consensus-based process.
@@ -36,34 +36,34 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 #### Role
 
-* Technical leadership of the GeoDa OpenJS project is delegated to the TSC by the OpenJS Cross Project Council (CPC) in accordance with the [GeoDa OpenJS Charter](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md).
-* The TSC's primary role is setting GeoDa OpenJS's technical & product direction based on the project's vision of empowering the AI era with powerful, accessible geospatial tools.
+* Technical leadership of the GeoDa AI project is delegated to the TSC by the OpenJS Cross Project Council (CPC) in accordance with the [GeoDa AI Charter](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md).
+* The TSC's primary role is setting GeoDa AI's technical & product direction based on the project's vision of empowering the AI era with powerful, accessible geospatial tools.
 * Creates a product roadmap in consultation with the Working Groups.
 * Creates Working Groups and sets the initial membership & initial Facilitator of the Working Groups.  The TSC may initiate the creation of Working Groups or a group of people with a common interest may request recognition as a Working Group.
 * Approves new Collaborators.
 * Sets and maintains the project guidelines.
 * Sets and maintains the project's feature and bug fix process.
 * Enforces the Code of Conduct.
-* Approves changes to the GeoDa OpenJS Charter and this document in coordination with the OpenJS CPC as described in the [GeoDa OpenJS Charter](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md).
-* The TSC may designate entities to perform security and privacy reviews of GeoDa OpenJS code/features.
+* Approves changes to the GeoDa AI Charter and this document in coordination with the OpenJS CPC as described in the [GeoDa AI Charter](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md).
+* The TSC may designate entities to perform security and privacy reviews of GeoDa AI code/features.
 * The TSC may escalate legal questions to the Foundation. 
 * Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.
 
 #### Membership
 
-* The TSC shall be composed of members with significant experience contributing to GeoDa OpenJS on a technical and product level.
+* The TSC shall be composed of members with significant experience contributing to GeoDa AI on a technical and product level.
 * Membership on the TSC is not time-limited.
 * The target size of the TSC is 3-6 members, but there is no fixed size.
 * Once established the TSC sets its own membership through the consensus-based process.
-* The TSC shall have a goal of having no more than ⅓ of the TSC from one employer.  Given the requirement that membership in the TSC requires recognized technical and/or product experience with GeoDa OpenJS this may not be feasible at the time the TSC is formed, but the TSC should actively work towards this goal.
+* The TSC shall have a goal of having no more than ⅓ of the TSC from one employer.  Given the requirement that membership in the TSC requires recognized technical and/or product experience with GeoDa AI this may not be feasible at the time the TSC is formed, but the TSC should actively work towards this goal.
 * Entities (such as a company) may be granted seats on the TSC.  In these cases certain conditions may be placed on the seat (such as maintaining committed resources to the project). The entity may designate the individual representing the entity at the TSC and may change this individual at their discretion.
 * The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process.
 
 ### Working Groups
 
 #### Role
-* A Working Group is a segment of the community with knowledge/interest in specific areas of GeoDa OpenJS (e.g. Spatial Analysis, AI Integration, UI/UX, Infrastructure, documentation) recognized by the TSC.
-* The TSC defines each Working Group's mandate, which may include responsibility for certain GeoDa OpenJS features, systems and/or code.  A Working Group generally operates independently on the area(s) in which it has a mandate while adhering to GeoDa OpenJS's project guidelines, vision/mission and technical/product roadmaps.
+* A Working Group is a segment of the community with knowledge/interest in specific areas of GeoDa AI (e.g. Spatial Analysis, AI Integration, UI/UX, Infrastructure, documentation) recognized by the TSC.
+* The TSC defines each Working Group's mandate, which may include responsibility for certain GeoDa AI features, systems and/or code.  A Working Group generally operates independently on the area(s) in which it has a mandate while adhering to GeoDa AI's project guidelines, vision/mission and technical/product roadmaps.
 * Each Working Group is made up of a set of Collaborators with knowledge/interest in that particular area + other interested parties.
 * Each Working Group's Facilitator is responsible for:
     * Facilitating consensus-based decisions within the Working Group.
@@ -79,7 +79,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 ## Decision making policy
 
-* Decisions in GeoDa OpenJS's Advisory Committee, TSC and Working Groups should be made using a [consensus-based approach](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) (similar to the [approach used by Node.js](https://nodejs.org/en/about/governance/#consensus-seeking-process) and [JS Foundation](https://github.com/JSFoundation/TAC/blob/master/TAC-Charter.md#section-8-decision-making)).
+* Decisions in GeoDa AI's Advisory Committee, TSC and Working Groups should be made using a [consensus-based approach](https://en.wikipedia.org/wiki/Consensus-seeking_decision-making) (similar to the [approach used by Node.js](https://nodejs.org/en/about/governance/#consensus-seeking-process) and [JS Foundation](https://github.com/JSFoundation/TAC/blob/master/TAC-Charter.md#section-8-decision-making)).
   * When discussions have appeared to reach a consensus, the Facilitator will ask if there are any objections to the apparent consensus.  A member may call a vote to finalize a decision, but this should only happen as a last resort.  With the agreement of two other members of the group the vote will be held, otherwise the consensus-seeking process will continue.
   * When votes are called:
     * The vote should be set at a time that allows a reasonable amount of time for those in the group to attend.  This time should be announced publicly.
@@ -97,7 +97,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 ## Developer Certificate of Origin
 
-* The GeoDa OpenJS Project uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) to ensure that contributors have the right to submit their contributions to the project.
+* The GeoDa AI Project uses the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) to ensure that contributors have the right to submit their contributions to the project.
 
 * All Owners, Collaborators, and Contributors who open a pull request must sign their commits using the DCO process by adding a `Signed-off-by` line to their commit messages.
 

--- a/README.md
+++ b/README.md
@@ -1,25 +1,25 @@
-# GeoDa OpenJS Project
+# GeoDa AI Project
 
-This is the repository for information about the GeoDa OpenJS project.
+This is the repository for information about the GeoDa AI project.
 
 ## Project Overview
 
-GeoDa OpenJS is a project to create modern Javascript libraries for spatial data analysis for the AI era.
+GeoDa AI is a project to create modern Javascript libraries for spatial data analysis for the AI era.
 
 ## Project Goals
 
-The goals of the GeoDa OpenJS project are to:
+The goals of the GeoDa AI project are to:
 
 - 1. Create a Javascript library for building AI Assistant with powerful data analysis tools and interactive React chat UI in [OpenAssistant repository](https://github.com/geodaai/openassistant)
 - 2. Create a modern Javascript library for spatial data analysis in [GeoDa-Lib repository](https://github.com/geodaai/geodalib)
 
 ## Project Governance
 
-The GeoDa OpenJS project charter is:
+The GeoDa AI project charter is:
 
 - [Charter](https://github.com/geodaai/geodaai.github.io/blob/main/CHARTER.md)
 
-The GeoDa OpenJS project uses the following governance model:
+The GeoDa AI project uses the following governance model:
 
 - [Governance](https://github.com/geodaai/geodaai.github.io/blob/main/GOVERNANCE.md)
 
@@ -39,7 +39,7 @@ The current members of the Technical Steering Committee are:
 
 ## Code of Conduct
 
-The GeoDa OpenJS project uses the following code of conduct:
+The GeoDa AI project uses the following code of conduct:
 
 - [Code of Conduct](https://github.com/geodaai/geodaai.github.io/blob/main/CODE_OF_CONDUCT.md)
 
@@ -47,8 +47,8 @@ This code of conduct defines the expected behavior of all participants in the pr
 
 ## Contributing
 
-The GeoDa OpenJS project welcomes contributions from the community. Please see the [Contributing](https://github.com/geodaai/geodaai.github.io/blob/main/CONTRIBUTING.md) file for more information.
+The GeoDa AI project welcomes contributions from the community. Please see the [Contributing](https://github.com/geodaai/geodaai.github.io/blob/main/CONTRIBUTING.md) file for more information.
 
 ## License
 
-The GeoDa OpenJS project is licensed under the [MIT License](https://github.com/geodaai/geodaai.github.io/blob/main/LICENSE).
+The GeoDa AI project is licensed under the [MIT License](https://github.com/geodaai/geodaai.github.io/blob/main/LICENSE).

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -7,7 +7,7 @@ import type * as Preset from '@docusaurus/preset-classic';
 const config: Config = {
   title: 'Spatial Data Analysis for GenAI',
   tagline:
-    '🚀 The GeoDa OpenJS project aims to develop modern JavaScript libraries for spatial data analysis that powers AI assistants with advanced geospatial tools and interactive interfaces 🤖',
+    '🚀 The GeoDa AI project aims to develop modern JavaScript libraries for spatial data analysis that powers AI assistants with advanced geospatial tools and interactive interfaces 🤖',
   favicon: 'img/favicon.ico',
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future
@@ -74,9 +74,9 @@ const config: Config = {
     // Replace with your project's social card
     image: 'img/docusaurus-social-card.jpg',
     navbar: {
-      title: 'GeoDa OpenJS Project',
+      title: 'GeoDa AI Project',
       logo: {
-        alt: 'GeoDa OpenJS Project Logo',
+        alt: 'GeoDa AI Project Logo',
         src: 'img/logo.svg',
       },
       items: [

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -133,17 +133,17 @@ function ExampleCard({
 export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
   return (
-    <Layout title="GeoDa OpenJS Project" description="GeoDa OpenJS Project">
+    <Layout title="GeoDa AI Project" description="GeoDa AI Project">
       <HomepageHeader />
       <main>
         <div className={styles.sectionHeading}>
           <h2>⚙️ Libraries</h2>
-          <h4>The GeoDa OpenJS libraries</h4>
+          <h4>The GeoDa AI libraries</h4>
         </div>
         <HomepageFeatures />
         <div className={styles.sectionHeading}>
           <h2>🚀 Projects</h2>
-          <h4>The projects that use GeoDa OpenJS libraries</h4>
+          <h4>The projects that use GeoDa AI libraries</h4>
         </div>
         <div className={styles.exampleCardsContainer}>
           <ExampleCard


### PR DESCRIPTION
This pull request updates the project branding from "GeoDa OpenJS" to "GeoDa AI" across multiple files to reflect a rebranding effort. The changes affect documentation, governance, and website configurations.

### Documentation and Governance Updates:
- **`GOVERNANCE.md`:** Updated terminology from "GeoDa OpenJS" to "GeoDa AI" throughout the document, including references to the Advisory Committee, Technical Steering Committee, and Working Groups. Adjusted links to reflect the new project name. [[1]](diffhunk://#diff-b60c6a93e9f74ee52e71bf33781c2870b8395c8c5a34f00f61305343cb8d8447L5-R15) [[2]](diffhunk://#diff-b60c6a93e9f74ee52e71bf33781c2870b8395c8c5a34f00f61305343cb8d8447L28-R28) [[3]](diffhunk://#diff-b60c6a93e9f74ee52e71bf33781c2870b8395c8c5a34f00f61305343cb8d8447L39-R66) [[4]](diffhunk://#diff-b60c6a93e9f74ee52e71bf33781c2870b8395c8c5a34f00f61305343cb8d8447L82-R82) [[5]](diffhunk://#diff-b60c6a93e9f74ee52e71bf33781c2870b8395c8c5a34f00f61305343cb8d8447L100-R100)
- **`README.md`:** Rebranded project name and description, including references to goals, governance, code of conduct, and licensing. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R22) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R54)

### Website Updates:
- **`website/docusaurus.config.ts`:** Updated the project title, tagline, and navbar logo alt text to reflect the new "GeoDa AI" branding. [[1]](diffhunk://#diff-1de336ccbebeecf69018f0a9d5559e7f033215d5f0c399933cfd686186b5b0fbL10-R10) [[2]](diffhunk://#diff-1de336ccbebeecf69018f0a9d5559e7f033215d5f0c399933cfd686186b5b0fbL77-R79)
- **`website/src/pages/index.tsx`:** Rebranded project name in the homepage layout and section headings.